### PR TITLE
Add clang++ maker for cpp files

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ Ruby:
 
 - rubocop
 
+C++:
+
+- clang++
+
 Since this list may be out of date, look in [autoload/neomake/makers](https://github.com/benekastah/neomake/tree/master/autoload/neomake/makers) for all supported makers.
 
 If you find this plugin useful, please contribute your maker recipes to the

--- a/autoload/neomake/makers/cpp.vim
+++ b/autoload/neomake/makers/cpp.vim
@@ -1,0 +1,20 @@
+" vim: ts=4 sw=4 et
+
+function! neomake#makers#cpp#EnabledMakers()
+    return ['clang']
+endfunction
+
+function! neomake#makers#cpp#clang()
+    return {
+        \ 'exe': 'clang++',
+        \ 'args': ['-fsyntax-only'],
+        \ 'errorformat':
+            \ '%-G%f:%s:,' .
+            \ '%f:%l:%c: %trror: %m,' .
+            \ '%f:%l:%c: %tarning: %m,' .
+            \ '%f:%l:%c: %m,'.
+            \ '%f:%l: %trror: %m,'.
+            \ '%f:%l: %tarning: %m,'.
+            \ '%f:%l: %m',
+        \ }
+endfunction


### PR DESCRIPTION
I added a maker for c++ files. It uses the clang compiler.