### PR TITLE
add gcc/g++ makers for c/c++ files

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,10 +101,12 @@ Ruby:
 C:
 
 - clang
+- gcc
 
 C++:
 
 - clang++
+- g++
 
 sh:
 

--- a/autoload/neomake/makers/c.vim
+++ b/autoload/neomake/makers/c.vim
@@ -1,13 +1,11 @@
 " vim: ts=4 sw=4 et
 
 function! neomake#makers#c#EnabledMakers()
-    let makers = []
     if neomake#utils#Exists('clang')
-        call add(makers, 'clang')
+        return ['clang']
     else
-        call add(makers, 'gcc')
+        return ['gcc']
     end
-    return makers
 endfunction
 
 function! neomake#makers#c#clang()

--- a/autoload/neomake/makers/c.vim
+++ b/autoload/neomake/makers/c.vim
@@ -1,7 +1,13 @@
 " vim: ts=4 sw=4 et
 
 function! neomake#makers#c#EnabledMakers()
-    return ['clang']
+    let makers = []
+    if neomake#utils#Exists('clang')
+        call add(makers, 'clang')
+    else
+        call add(makers, 'gcc')
+    end
+    return makers
 endfunction
 
 function! neomake#makers#c#clang()

--- a/autoload/neomake/makers/c.vim
+++ b/autoload/neomake/makers/c.vim
@@ -18,3 +18,22 @@ function! neomake#makers#c#clang()
             \ '%f:%l: %m',
         \ }
 endfunction
+
+function! neomake#makers#c#gcc()
+    return {
+        \ 'exe': 'clang',
+        \ 'args': ['-fsyntax-only'],
+        \ 'errorformat':
+            \ '%-G%f:%s:,' .
+            \ '%-G%f:%l: %#error: %#(Each undeclared identifier is reported only%.%#,' .
+            \ '%-G%f:%l: %#error: %#for each function it appears%.%#,' .
+            \ '%-GIn file included%.%#,' .
+            \ '%-G %#from %f:%l\,,' .
+            \ '%f:%l:%c: %trror: %m,' .
+            \ '%f:%l:%c: %tarning: %m,' .
+            \ '%f:%l:%c: %m,' .
+            \ '%f:%l: %trror: %m,' .
+            \ '%f:%l: %tarning: %m,'.
+            \ '%f:%l: %m',
+        \ }
+endfunction

--- a/autoload/neomake/makers/cpp.vim
+++ b/autoload/neomake/makers/cpp.vim
@@ -1,13 +1,11 @@
 " vim: ts=4 sw=4 et
 
 function! neomake#makers#cpp#EnabledMakers()
-    let makers = []
     if neomake#utils#Exists('clang++')
-        call add(makers, 'clang')
+        return ['clang']
     else
-        call add(makers, 'gcc')
+        return ['gcc']
     end
-    return makers
 endfunction
 
 function! neomake#makers#cpp#clang()

--- a/autoload/neomake/makers/cpp.vim
+++ b/autoload/neomake/makers/cpp.vim
@@ -9,3 +9,9 @@ function! neomake#makers#cpp#clang()
     let maker.exe = 'clang++'
     return maker
 endfunction
+
+function! neomake#makers#cpp#gcc()
+    let maker = neomake#makers#c#gcc()
+    let maker.exe = 'g++'
+    return maker
+endfunction

--- a/autoload/neomake/makers/cpp.vim
+++ b/autoload/neomake/makers/cpp.vim
@@ -1,7 +1,13 @@
 " vim: ts=4 sw=4 et
 
 function! neomake#makers#cpp#EnabledMakers()
-    return ['clang']
+    let makers = []
+    if neomake#utils#Exists('clang++')
+        call add(makers, 'clang')
+    else
+        call add(makers, 'gcc')
+    end
+    return makers
 endfunction
 
 function! neomake#makers#cpp#clang()


### PR DESCRIPTION
Not everybody has clang. Since clang is a bit faster (I think) clang is the prefered maker, but I added gcc as a fallback maker.