### PR TITLE
Add Frosted maker for python.

### DIFF
--- a/autoload/neomake/makers/python.vim
+++ b/autoload/neomake/makers/python.vim
@@ -5,11 +5,11 @@ function! neomake#makers#python#EnabledMakers()
         return s:python_makers
     endif
 
-    let makers = ['python']
+    let makers = ['python', 'frosted']
     if neomake#utils#Exists('flake8')
         call add(makers, 'flake8')
     else
-        call extend(makers, ['pep8', 'frosted', 'pyflakes'])
+        call extend(makers, ['pep8', 'pyflakes'])
     endif
     call add(makers, 'pylint')  " Last because it is the slowest
 

--- a/autoload/neomake/makers/python.vim
+++ b/autoload/neomake/makers/python.vim
@@ -9,7 +9,7 @@ function! neomake#makers#python#EnabledMakers()
     if neomake#utils#Exists('flake8')
         call add(makers, 'flake8')
     else
-        call extend(makers, ['pep8', 'pyflakes'])
+        call extend(makers, ['pep8', 'frosted', 'pyflakes'])
     endif
     call add(makers, 'pylint')  " Last because it is the slowest
 
@@ -73,5 +73,19 @@ function! neomake#makers#python#python()
             \ "    print('%s:%s:%s: %s' % (err.filename, err.lineno, err.offset, err.msg))"
         \ ],
         \ 'errorformat': '%E%f:%l:%c: %m',
+        \ }
+endfunction
+
+function! neomake#makers#python#frosted()
+    return {
+        \ 'args': [
+            \ '-vb'
+        \ ],
+        \ 'errorformat':
+            \ '%f:%l:%c:%t%n:%s:%m,' .
+            \ '%f:%l:%c:%m,' .
+            \ '%E%f:%l: %m,' .
+            \ '%-Z%p^,' .
+            \ '%-G%.%#'
         \ }
 endfunction


### PR DESCRIPTION
Mostly taken from Syntactic, but prepended an extra row to `errorformat` to try and correctly identify warnings vs. errors and tag accordingly.

However I'm not sure where to place it in the list of checkers.

>Frosted is a fork of pyflakes (originally created by Phil Frost) that aims at more open contribution from the outside public, a smaller more maintainable code base, and a better Python checker for all.

https://github.com/timothycrosley/frosted