### PR TITLE
add maker for rust and fix gcc maker exe

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,9 @@ sh:
 zsh:
 - shellcheck
 
+Rust:
+- rustc
+
 Since this list may be out of date, look in [autoload/neomake/makers](https://github.com/benekastah/neomake/tree/master/autoload/neomake/makers) for all supported makers.
 
 If you find this plugin useful, please contribute your maker recipes to the

--- a/autoload/neomake/makers/c.vim
+++ b/autoload/neomake/makers/c.vim
@@ -25,7 +25,7 @@ endfunction
 
 function! neomake#makers#c#gcc()
     return {
-        \ 'exe': 'clang',
+        \ 'exe': 'gcc',
         \ 'args': ['-fsyntax-only'],
         \ 'errorformat':
             \ '%-G%f:%s:,' .

--- a/autoload/neomake/makers/c.vim
+++ b/autoload/neomake/makers/c.vim
@@ -10,7 +10,6 @@ endfunction
 
 function! neomake#makers#c#clang()
     return {
-        \ 'exe': 'clang',
         \ 'args': ['-fsyntax-only'],
         \ 'errorformat':
             \ '%-G%f:%s:,' .
@@ -25,7 +24,6 @@ endfunction
 
 function! neomake#makers#c#gcc()
     return {
-        \ 'exe': 'gcc',
         \ 'args': ['-fsyntax-only'],
         \ 'errorformat':
             \ '%-G%f:%s:,' .

--- a/autoload/neomake/makers/rust.vim
+++ b/autoload/neomake/makers/rust.vim
@@ -1,7 +1,7 @@
 " vim: ts=4 sw=4 et
 
 function! neomake#makers#rust#EnabledMakers()
-    return ['cargo']
+    return ['rustc']
 endfunction
 
 function! neomake#makers#rust#cargo()
@@ -31,3 +31,5 @@ function! neomake#makers#rust#rustc()
             \ '%f:%l: %m',
         \ }
 endfunction
+
+let g:neomake_cargo_maker = neomake#makers#rust#cargo()

--- a/autoload/neomake/makers/rust.vim
+++ b/autoload/neomake/makers/rust.vim
@@ -20,7 +20,7 @@ endfunction
 
 function! neomake#makers#rust#rustc()
     return {
-        \ 'args': ['-o /dev/null'],
+        \ 'args': ['-o', neomake#utils#DevNull()],
         \ 'errorformat':
             \ '%-G%f:%s:,' .
             \ '%f:%l:%c: %trror: %m,' .

--- a/autoload/neomake/makers/rust.vim
+++ b/autoload/neomake/makers/rust.vim
@@ -1,7 +1,21 @@
 " vim: ts=4 sw=4 et
 
 function! neomake#makers#rust#EnabledMakers()
-    return ['rustc']
+    return ['cargo']
+endfunction
+
+function! neomake#makers#rust#cargo()
+    return {
+        \ 'args': ['build'],
+        \ 'errorformat':
+            \ '%-G%f:%s:,' .
+            \ '%f:%l:%c: %trror: %m,' .
+            \ '%f:%l:%c: %tarning: %m,' .
+            \ '%f:%l:%c: %m,'.
+            \ '%f:%l: %trror: %m,'.
+            \ '%f:%l: %tarning: %m,'.
+            \ '%f:%l: %m',
+        \ }
 endfunction
 
 function! neomake#makers#rust#rustc()

--- a/autoload/neomake/makers/rust.vim
+++ b/autoload/neomake/makers/rust.vim
@@ -1,0 +1,18 @@
+" vim: ts=4 sw=4 et
+
+function! neomake#makers#rust#EnabledMakers()
+    return ['rustc']
+endfunction
+
+function! neomake#makers#rust#rustc()
+    return {
+        \ 'errorformat':
+            \ '%-G%f:%s:,' .
+            \ '%f:%l:%c: %trror: %m,' .
+            \ '%f:%l:%c: %tarning: %m,' .
+            \ '%f:%l:%c: %m,'.
+            \ '%f:%l: %trror: %m,'.
+            \ '%f:%l: %tarning: %m,'.
+            \ '%f:%l: %m',
+        \ }
+endfunction

--- a/autoload/neomake/makers/rust.vim
+++ b/autoload/neomake/makers/rust.vim
@@ -32,4 +32,5 @@ function! neomake#makers#rust#rustc()
         \ }
 endfunction
 
+"TODO: when #47 is fulfiled, update this to be cleaner
 let g:neomake_cargo_maker = neomake#makers#rust#cargo()

--- a/autoload/neomake/makers/rust.vim
+++ b/autoload/neomake/makers/rust.vim
@@ -4,6 +4,7 @@ function! neomake#makers#rust#EnabledMakers()
     return ['rustc']
 endfunction
 
+"TODO: when #47 is fulfiled, add this as a `Neomake!` maker for rust
 function! neomake#makers#rust#cargo()
     return {
         \ 'args': ['build'],
@@ -31,6 +32,3 @@ function! neomake#makers#rust#rustc()
             \ '%f:%l: %m',
         \ }
 endfunction
-
-"TODO: when #47 is fulfiled, update this to be cleaner
-let g:neomake_cargo_maker = neomake#makers#rust#cargo()

--- a/autoload/neomake/makers/rust.vim
+++ b/autoload/neomake/makers/rust.vim
@@ -6,6 +6,7 @@ endfunction
 
 function! neomake#makers#rust#rustc()
     return {
+        \ 'args': ['-o /dev/null'],
         \ 'errorformat':
             \ '%-G%f:%s:,' .
             \ '%f:%l:%c: %trror: %m,' .


### PR DESCRIPTION
The `gcc` maker had its exe field set to `clang`. This PR fixes that.

I also added a basic maker for the Rust programming language.