### PR TITLE
Add ruby checker to neomake

### DIFF
--- a/autoload/neomake/makers/ft/ruby.vim
+++ b/autoload/neomake/makers/ft/ruby.vim
@@ -1,12 +1,31 @@
 " vim: ts=4 sw=4 et
 
 function! neomake#makers#ft#ruby#EnabledMakers()
-    return ['rubocop']
+    return ['mri', 'rubocop']
 endfunction
 
 function! neomake#makers#ft#ruby#rubocop()
     return {
         \ 'args': ['--format', 'emacs'],
         \ 'errorformat': '%f:%l:%c: %t: %m'
+        \ }
+endfunction
+
+function neomake#makers#ft#ruby#mri()
+    let errorformat = '%-G%\m%.%#warning: %\%%(possibly %\)%\?useless use of == in void context,'
+    let errorformat .= '%-G%\%.%\%.%\%.%.%#,'
+    let errorformat .=
+        \ '%-GSyntax OK,'.
+        \ '%E%f:%l: syntax error\, %m,'.
+        \ '%Z%p^,'.
+        \ '%W%f:%l: warning: %m,'.
+        \ '%Z%p^,'.
+        \ '%W%f:%l: %m,'.
+        \ '%-C%.%#'
+
+    return {
+        \ 'exe': 'ruby',
+        \ 'args': ['-c', '-T1', '-w'],
+        \ 'errorformat': errorformat
         \ }
 endfunction


### PR DESCRIPTION
This add the ruby checker the way syntastic checks, so if you do not have rubocop you can at least have basic checks from the ruby interpreter.
The syntax was not build by me, I borrowed from syntastic.