### PR TITLE
Use Vim builtin 'strftime' to create timestamps in logs.

### DIFF
--- a/autoload/neomake/utils.vim
+++ b/autoload/neomake/utils.vim
@@ -15,8 +15,8 @@ function! neomake#utils#LogMessage(level, msg) abort
         endif
     endif
     if type(logfile) ==# type('') && len(logfile)
+        let date = strftime("%Y-%m-%dT%H:%M:%S%z")
         " TODO make this cross platform
-        let date = substitute(system('date'), '\n$', '', '')
         call system(
             \ 'cat >> '.shellescape(logfile),
             \ date.' Log level '.a:level.': '.msg."\n")


### PR DESCRIPTION
Just stumbled upon the TODO while reading the code, so here is a solution.

Disclaimer: I have not actually tested the code on other platforms, but it did not break anything on my Linux and according to https://msdn.microsoft.com/en-us/library/fe06s4ak.aspx all the format characters used here are supported on Windows.

Edit: just realized the call to `cat` below is not cross-platform, but I am not aware of an easy way in Vimscript to append a string to a file (without reading the entire file first).