### PR TITLE
Do not use 'cat' to create a temp file.

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -207,8 +207,9 @@ function! neomake#Make(options) abort
                 let tempfile = 1
                 let tempsuffix = '.'.neomake#utils#Random().'.neomake.tmp'
                 let makepath .= tempsuffix
-                " TODO Make this cross platform
-                silent exe 'w !cat > '.shellescape(makepath)
+                let escapedpath = fnameescape(makepath)
+                noautocmd silent exe 'keepalt w! '.escapedpath
+                noautocmd silent exe 'bwipeout '.escapedpath
                 call neomake#utils#LoudMessage('Neomake: wrote temp file '.makepath)
             endif
         endif


### PR DESCRIPTION
Just found another "TODO Make this cross platform". 

I am a Vimscript newbie, so I am not sure why this trick with `cat` was used in the first place. My tests did not reveal a difference between the two versions.