### PR TITLE
Delete the temporary file even if the working directory has changed.

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -202,7 +202,7 @@ function! neomake#Make(options) abort
         let tempsuffix = ''
         let makepath = ''
         if file_mode
-            let makepath = expand('%')
+            let makepath = expand('%:p')
             if get(g:, 'neomake_make_modified', 0) && &mod
                 let tempfile = 1
                 let tempsuffix = '.'.neomake#utils#Random().'.neomake.tmp'


### PR DESCRIPTION
Referring to temporary files by their full, expanded path allows neomake to still find the temporary file if the working directory changes between the moment where the temp file is created and the moment it should be deleted.

This is a corner case, but as I am testing #59 I am forcing neomake to write a temporary file each time it performs a check, and in combination with the plugin [vimfiler](https://github.com/Shougo/vimfiler.vim) which temporarily changes the working directory when performing a rename, I have temp files laying around after a rename.