### PR TITLE
Wait for the next maker first error (or end) to remove signs.

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -187,13 +187,11 @@ function! neomake#Make(options) abort
 
     if file_mode
         let b:neomake_loclist_nr = 0
-        let b:neomake_errors = {}
-        " Remove any signs we placed before
-        let b:neomake_signs = get(b:, 'neomake_signs', {})
-        for ln in keys(b:neomake_signs)
-            exe 'sign unplace '.b:neomake_signs[ln]
-        endfor
-        let b:neomake_signs = {}
+        " Mark that the signs must be removed on the first error returned by
+        " the maker.
+        " Signs are not deleted when the maker execution starts
+        " because some makers take a long time to return their first result.
+        let b:neomake_signs_cleared = 0
     endif
 
     let serialize = get(g:, 'neomake_serialize')
@@ -294,6 +292,12 @@ function! s:AddExprCallback(maker) abort
             endif
             if !entry.valid
                 continue
+            endif
+
+            " On the first valid error identified by a maker,
+            " clear the existing signs in the buffer
+            if !b:neomake_signs_cleared
+                call neomake#ClearSignsAndErrors()
             endif
 
             " Track all errors by line
@@ -481,6 +485,13 @@ function! neomake#MakeHandler(...) abort
         else
             call neomake#utils#QuietMessage(msg)
         endif
+
+        " If signs were not cleared before this point, then the maker did not return
+        " any errors, so all signs must be removed
+        if !b:neomake_signs_cleared
+            call neomake#ClearSignsAndErrors()
+        endif
+
         " Show the current line's error
         call neomake#CursorMoved()
 
@@ -494,6 +505,16 @@ function! neomake#MakeHandler(...) abort
             endif
         endif
     endif
+endfunction
+
+function! neomake#ClearSignsAndErrors() abort
+    let b:neomake_signs = get(b:, 'neomake_signs', {})
+    for ln in keys(b:neomake_signs)
+        exe 'sign unplace '.b:neomake_signs[ln]
+    endfor
+    let b:neomake_signs = {}
+    let b:neomake_signs_cleared = 1
+    let b:neomake_errors = {}
 endfunction
 
 function! neomake#CursorMoved() abort


### PR DESCRIPTION
Some makers (e.g. rubocop running on JRuby) may take a few seconds to return the first error (in this case, because of the JVM startup time). Neomake currently removes all signs and errors as soon as `:Neomake` is called, but this is a problem with makers that take a while to start.

For instance, I have bound `:Neomake` to `Bufwrite`. Let's assume that a maker gave two errors, one on line 1 and one on line 2. If I fix the first error, then (out of habit) type `:w`, I have to wait a few seconds before the error on line 2 appears again.

With this PR, signs and errors are not cleared when `:Neomake` is called, but when the first maker starts returning an error or is finished. This helped my workflow with JRuby, and may be useful when #46 is implemented, as building/checking large projects can take some time before the current buffer is processed.

However, this could be an option rather than the default (or may be a bad idea in general :) ). What is your opinion about it?