### PR TITLE
Remove flaky error format from Frosted (Py) checker.

### DIFF
--- a/autoload/neomake/makers/ft/python.vim
+++ b/autoload/neomake/makers/ft/python.vim
@@ -82,7 +82,6 @@ function! neomake#makers#ft#python#frosted()
             \ '-vb'
         \ ],
         \ 'errorformat':
-            \ '%f:%l:%c:%t%n:%s:%m,' .
             \ '%f:%l:%c:%m,' .
             \ '%E%f:%l: %m,' .
             \ '%-Z%p^,' .


### PR DESCRIPTION
This line broke "jump-to-error-line" from the location window. This is something I added in https://github.com/benekastah/neomake/pull/45 which wasn't included by Syntastic, I thought it would produce a bit more exhaustive match with error type (`%t`) and error number (`%n`), but it seems like it broke more than it added.