### PR TITLE
Add vim-airline extension.

### DIFF
--- a/autoload/airline/extensions/neomake.vim
+++ b/autoload/airline/extensions/neomake.vim
@@ -1,3 +1,9 @@
+" vim: ts=4 sw=4 et
+
+if exists('g:neomake_airline') && g:neomake_airline == 0
+    finish
+endif
+
 let s:spc = g:airline_symbols.space
 
 function! airline#extensions#neomake#apply(...)

--- a/autoload/airline/extensions/neomake.vim
+++ b/autoload/airline/extensions/neomake.vim
@@ -1,0 +1,11 @@
+let s:spc = g:airline_symbols.space
+
+function! airline#extensions#neomake#apply(...)
+    let w:airline_section_warning = get(w:, 'airline_section_warning', g:airline_section_warning)
+    let w:airline_section_warning .= s:spc.'%{neomake#statusline#LoclistStatus()}'
+endfunction
+
+function! airline#extensions#neomake#init(ext)
+    call airline#parts#define_raw('neomake', '%{neomake#statusline#LoclistStatus()}')
+    call a:ext.add_statusline_func('airline#extensions#neomake#apply')
+endfunction

--- a/doc/neomake.txt
+++ b/doc/neomake.txt
@@ -185,6 +185,10 @@ definition: >
 See the |:highlight| command to list the highlight groups available to you or
 create new ones.
 
+*g:neomake_airline*
+Shows the ouput returned by |neomake#statusline#LoclistStatus| in the warning
+section of the vim-airline |statusline|. Defaults to 1.
+
 ==============================================================================
 4. Functions                                                 *neomake-functions*
 


### PR DESCRIPTION
Add statusline extension for vim-airline. The lines got a bit long, do you want me to wrap them?

It's that `E:4` to the right:
![screen shot 2015-03-26 at 13 28 11](https://cloud.githubusercontent.com/assets/177685/6846191/6cb8001e-d3bc-11e4-91db-efc10a8b982f.png)