### PR TITLE
Adapt job spawning and handlers for Neovim new job control API.

### DIFF
--- a/plugin/neomake.vim
+++ b/plugin/neomake.vim
@@ -27,10 +27,6 @@ command! NeomakeListJobs call neomake#ListJobs()
 
 augroup neomake
     autocmd!
-    if has('nvim')
-        autocmd JobActivity neomake* call neomake#MakeHandler()
-    endif
-
     autocmd BufEnter,CursorHold * call neomake#ProcessCurrentBuffer()
 augroup END
 


### PR DESCRIPTION
Closes #72 #74.

This is a direct adaptation of the existing code to make it work, but the new API should allow further improvements: cleaner code thanks to the `opts` parameter of `jobstart`, proper handling of exit code...