### PR TITLE
Add a note in the README about the minimum Neovim version required by Neomake.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ things may break and change often until they do. That said, I'm using it daily
 (but also hacking on it as it breaks). Feel free to let me know what works /
 doesn't work for you!
 
+The minimum Neovim version supported by Neomake is `NVIM 0.0.0-alpha+201503292107` (commit `960b9108c`).
+
 ## How to use (basic)
 
 Just set your `makeprg` and `errorformat` as normal, and run:


### PR DESCRIPTION
Related to #75, to help users who update neomake without having updated neovim.