### PR TITLE
checker for Sass

### DIFF
--- a/autoload/neomake/makers/ft/scss.vim
+++ b/autoload/neomake/makers/ft/scss.vim
@@ -1,0 +1,12 @@
+" vim: ts=4 sw=4 et
+
+function! neomake#makers#ft#scss#EnabledMakers()
+    return ['scsslint']
+endfunction
+
+function! neomake#makers#ft#scss#scsslint()
+    return {
+        \ 'exe': 'scss-lint',
+        \ 'errorformat': '%f:%l [%t] %m'
+    \ }
+endfunction


### PR DESCRIPTION
[Sass](http://sass-lang.com/) is a langage that extends and compiles into [CSS](http://en.wikipedia.org/wiki/Cascading_Style_Sheets); [`scss-lint`](https://github.com/brigade/scss-lint) is a linter for Sass.