### PR TITLE
Use :language messages instead of :language

### DIFF
--- a/autoload/neomake/signs.vim
+++ b/autoload/neomake/signs.vim
@@ -30,9 +30,9 @@ function! neomake#signs#GetSigns(...) abort
     endfor
     call neomake#utils#DebugMessage('executing: '.place_cmd)
     let curlang=v:lang
-    language en_US.utf8
+    language messages en_US.utf8
     redir => signs_txt | silent exe place_cmd | redir END
-    silent exe "language ".curlang
+    silent exe "language messages ".curlang
     let fname_pattern = 'Signs for \(.*\):'
     for s in split(signs_txt, '\n')
         if s =~# fname_pattern


### PR DESCRIPTION
#97 uses `:language` to change locale to `en_US.utf8`, which is not available on Windows. In this case we only need to set language for messages, so `:language messages` should work fine (and it works on Windows).