### PR TITLE
Add a way to alter quickfix or location list entries.

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -240,6 +240,11 @@ function! s:AddExprCallback(maker) abort
         let entry = list[s:neomake_list_nr]
         let s:neomake_list_nr += 1
 
+        if has_key(a:maker, 'postprocess')
+            let Func = a:maker.postprocess
+            call Func(entry)
+        end
+
         if entry.valid && !file_mode
             call neomake#statusline#AddQflistCount(entry)
         endif

--- a/autoload/neomake/makers/ft/ruby.vim
+++ b/autoload/neomake/makers/ft/ruby.vim
@@ -7,8 +7,17 @@ endfunction
 function! neomake#makers#ft#ruby#rubocop()
     return {
         \ 'args': ['--format', 'emacs'],
-        \ 'errorformat': '%f:%l:%c: %t: %m'
+        \ 'errorformat': '%f:%l:%c: %t: %m',
+        \ 'postprocess': function('neomake#makers#ft#ruby#RubocopEntryProcess')
         \ }
+endfunction
+
+function! neomake#makers#ft#ruby#RubocopEntryProcess(entry)
+    if a:entry.type ==# 'F'
+        let a:entry.type = 'E'
+    elseif a:entry.type !=# 'W' && a:entry.type !=# 'E'
+        let a:entry.type = 'W'
+    endif
 endfunction
 
 function neomake#makers#ft#ruby#mri()

--- a/doc/neomake.txt
+++ b/doc/neomake.txt
@@ -105,13 +105,29 @@ This will cause "lint /path/to/file.c --option x" to be run instead of
 "lint --option x /path/to/file.c".
 
                                                      *neomake-makers-processing*
-Sometimes a maker's output may require some processing. For this, there is the
-optional mapexpr property that you can define on a maker object. It will be
-passed directly into |map| as the expr argument like so: >
+You can define two optional properties on a maker object to process the maker
+output: 'mapexpr' is applied to the maker output before any processing, and
+'postprocess' is applied to the quickfix or location list entry.
+
+The 'mapexpr' property will be passed directly into |map| as the expr argument like so: >
     call map(lines, maker.mapexpr)
-<This allows you to manipulate the lines as needed. Currently this is called
+<where 'lines' contains the maker output.
+This allows you to manipulate the lines as needed. Currently this is called
 on stdout and stderr lines alike.
 
+The 'postprocess' property is a function reference that will be applied to the
+entry in the location or quickfix list.
+Example: change the entry type to a warning. >
+    function SetWarningType(entry)
+        a:entry.type = 'W'
+    endfunction
+    let g:neomake_c_lint_maker = {
+        \ 'exe': 'lint',
+        \ 'args': ['--option', 'x'],
+        \ 'errorformat': '%f:%l:%c: %m',
+        \ 'postprocess': function('SetWarningType')
+        \ }
+<
                                                   *neomake-makers-buffer_output*
 Some makers with multiline error messages have issues (depending on how they
 flush their output). If multiline errorformats seem to work inconsistently for


### PR DESCRIPTION
This is a possible solution to #94: allow makers to change entries in the quickfix or location list before they are further processed by neomake (in the rubocop case, normalize the error type to 'W' or 'E').

`mapexpr` is not really adapted for this case, since to accurately find out what to change in rubocop output we would need to parse its output like `errorformat` does. I find it more robust to work on the entry objects.

The post processing function for rubocop comes from Syntastic.