### PR TITLE
Fix availability check

### DIFF
--- a/autoload/neomake/utils.vim
+++ b/autoload/neomake/utils.vim
@@ -146,7 +146,7 @@ function! neomake#utils#MakerIsAvailable(ft, maker_name) abort
         return 1
     endif
     if !has_key(s:available_makers, a:maker_name)
-        let maker = neomake#GetMaker(a:maker_name, '', a:ft)
+        let maker = neomake#GetMaker(a:maker_name, a:ft)
         let s:available_makers[a:maker_name] = neomake#utils#Exists(maker.exe)
     endif
     return s:available_makers[a:maker_name]


### PR DESCRIPTION
The neomake#GetMaker interface changed (in f29e7e1de76ca7c9e3f3ae2e6a2e384c400a8436) and therefore only default makers
were returned. This broke the check for makers that changed the exe name
(ie. ruby#mri).