### PR TITLE
Remove s:last_modified_signs.

### DIFF
--- a/autoload/neomake/signs.vim
+++ b/autoload/neomake/signs.vim
@@ -6,7 +6,6 @@ function! neomake#signs#Reset() abort
         call neomake#signs#CleanOldSigns()
     endif
     let s:last_placed_signs = get(s:, 'placed_signs', {})
-    let s:last_modified_signs = get(s:, 'modified_signs', {})
     let s:sign_id = 5000
     let s:placed_signs = {}
     let s:modified_signs = {}
@@ -57,14 +56,7 @@ function! neomake#signs#CleanOldSigns() abort
             exe cmd
         endfor
     endfor
-    for buf in keys(s:last_modified_signs)
-        for sign in s:last_modified_signs[buf]
-            " We changed the sign's name, so change it back
-            exe 'sign place '.sign.id.' name='.sign.name.' buffer='.buf
-        endfor
-    endfor
     let s:last_placed_signs = {}
-    let s:last_modified_signs = {}
 endfunction
 
 function! neomake#signs#PlaceVisibleSigns() abort

--- a/autoload/neomake/signs.vim
+++ b/autoload/neomake/signs.vim
@@ -8,7 +8,6 @@ function! neomake#signs#Reset() abort
     let s:last_placed_signs = get(s:, 'placed_signs', {})
     let s:sign_id = 5000
     let s:placed_signs = {}
-    let s:modified_signs = {}
 endfunction
 call neomake#signs#Reset()
 


### PR DESCRIPTION
Does that variable have a purpose, or is it just a leftover?

This commit removes all occurrences of this variable, since it can only have the value `{}`, but maybe there is a detail I am not aware of.

Edit: same remark for s:modified_signs.