### PR TITLE
Fix NeomakeSh maker generation

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -84,29 +84,29 @@ function! neomake#MakeJob(maker) abort
     endif
 endfunction
 
-function! neomake#GetMaker(maker_id, ...) abort
+function! neomake#GetMaker(name_or_maker, ...) abort
     if a:0
         let ft = a:1
     else
         let ft = ''
     endif
-    if type(a:maker_id) == type({})
-        let maker = a:maker_id
+    if type(a:name_or_maker) == type({})
+        let maker = a:name_or_maker
     else
-        if a:maker_id ==# 'makeprg'
+        if a:name_or_maker ==# 'makeprg'
             let maker = neomake#utils#MakerFromCommand(&shell, &makeprg)
         elseif len(ft)
-            let maker = get(g:, 'neomake_'.ft.'_'.a:maker_id.'_maker')
+            let maker = get(g:, 'neomake_'.ft.'_'.a:name_or_maker.'_maker')
         else
-            let maker = get(g:, 'neomake_'.a:maker_id.'_maker')
+            let maker = get(g:, 'neomake_'.a:name_or_maker.'_maker')
         endif
         if type(maker) == type(0)
             unlet maker
             try
                 if len(ft)
-                    let maker = eval('neomake#makers#ft#'.ft.'#'.a:maker_id.'()')
+                    let maker = eval('neomake#makers#ft#'.ft.'#'.a:name_or_maker.'()')
                 else
-                    let maker = eval('neomake#makers#'.a:maker_id.'#'.a:maker_id.'()')
+                    let maker = eval('neomake#makers#'.a:name_or_maker.'#'.a:name_or_maker.'()')
                 endif
             catch /^Vim\%((\a\+)\)\=:E117/
                 let maker = {}
@@ -115,10 +115,10 @@ function! neomake#GetMaker(maker_id, ...) abort
     endif
     let maker = copy(maker)
     if !has_key(maker, 'name')
-        let maker.name = a:maker_id
+        let maker.name = a:name_or_maker
     endif
     let defaults = {
-        \ 'exe': a:maker_id,
+        \ 'exe': maker.name,
         \ 'args': [],
         \ 'errorformat': '',
         \ 'buffer_output': 0,

--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -96,7 +96,7 @@ function! neomake#GetMaker(maker_id, ...) abort
         if a:maker_id ==# 'makeprg'
             let maker = neomake#utils#MakerFromCommand(&shell, &makeprg)
         elseif len(ft)
-            let maker = get(g:, 'neomake_'.ft.'_'.a:name.'_maker')
+            let maker = get(g:, 'neomake_'.ft.'_'.a:maker_id.'_maker')
         else
             let maker = get(g:, 'neomake_'.a:maker_id.'_maker')
         endif

--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -114,10 +114,13 @@ function! neomake#GetMaker(maker_id, ...) abort
         endif
     endif
     let maker = copy(maker)
+    if !has_key(maker, 'name')
+        let maker.name = a:maker_id
+    endif
     let defaults = {
         \ 'exe': a:maker_id,
         \ 'args': [],
-        \ 'errorformat': '%E',
+        \ 'errorformat': '',
         \ 'buffer_output': 0,
         \ }
     for key in keys(defaults)
@@ -132,9 +135,6 @@ function! neomake#GetMaker(maker_id, ...) abort
             let maker[key] = defaults[key]
         endif
     endfor
-    if !has_key(maker, 'name')
-        let maker.name = a:maker_id
-    endif
     let maker.ft = ft
     " Only relevant if file_mode is used
     let maker.winnr = winnr()
@@ -289,7 +289,7 @@ function! s:ProcessJobOutput(maker, lines) abort
     call neomake#utils#DebugMessage(get(a:maker, 'name', 'makeprg').' processing '.
                                     \ len(a:lines).' lines of output')
     if len(a:lines) > 0
-        if has_key(a:maker, 'errorformat')
+        if len(a:maker.errorformat)
             let olderrformat = &errorformat
             let &errorformat = a:maker.errorformat
         endif


### PR DESCRIPTION
There are 3 changes:

 * Change `GetMaker` parameter to `maker_id` so it's clear that it's not always a name
 * Set default `errorformat` to something that is usable
 * use `maker.name` for the config vars instead of `a:name` since it could be a dictionary

Fixes #109