### PR TITLE
Add an option to remove invalid entries from the location/quickfix list.

### DIFF
--- a/doc/neomake.txt
+++ b/doc/neomake.txt
@@ -142,6 +142,13 @@ This tells the maker only to process output when either the output type
 changes (from stderr to stout or vice versa) or at the end of the job. Your
 results will take longer, but multiline error messages should parse properly.
 
+				         *neomake-makers-remove_invalid_entries*
+Makers can filter invalid entries (e.g. entries that do not match the
+|errorformat|) in the location/quickfix list. Set the 'remove_invalid_entries'
+property to 0 to keep all the maker output in the list:
+    let g:neomake_ft_maker_remove_invalid_entries = 0
+<
+
 Global Options                                                 *neomake-options*
 
 *g:neomake_<name>_maker* *g:neomake_<ft>_<name>_maker*


### PR DESCRIPTION
Fix #27.