### PR TITLE
remember makeprg errorformat

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -94,7 +94,7 @@ function! neomake#GetMaker(name_or_maker, ...) abort
         let maker = a:name_or_maker
     else
         if a:name_or_maker ==# 'makeprg'
-            let maker = neomake#utils#MakerFromCommand(&shell, &makeprg)
+            let maker = neomake#utils#MakerFromCommand(&shell, &makeprg, &errorformat)
         elseif len(ft)
             let maker = get(g:, 'neomake_'.ft.'_'.a:name_or_maker.'_maker')
         else

--- a/autoload/neomake/utils.vim
+++ b/autoload/neomake/utils.vim
@@ -121,7 +121,7 @@ function! neomake#utils#Random() abort
     return answer
 endfunction
 
-function! neomake#utils#MakerFromCommand(shell, command) abort
+function! neomake#utils#MakerFromCommand(shell, command, errorformat) abort
     let command = substitute(a:command, '%\(:[a-z]\)*',
                            \ '\=expand(submatch(0))', 'g')
     let shell_name = split(a:shell, '/')[-1]
@@ -134,7 +134,8 @@ function! neomake#utils#MakerFromCommand(shell, command) abort
     endif
     return {
         \ 'exe': a:shell,
-        \ 'args': args
+        \ 'args': args,
+        \ 'errorformat': a:errorformat
         \ }
 endfunction
 

--- a/plugin/neomake.vim
+++ b/plugin/neomake.vim
@@ -19,7 +19,7 @@ function! s:NeomakeCommand(file_mode, enabled_makers)
 endfunction
 
 function! s:NeomakeSh(sh_command)
-    let custom_maker = neomake#utils#MakerFromCommand(&shell, a:sh_command)
+    let custom_maker = neomake#utils#MakerFromCommand(&shell, a:sh_command, '')
     let custom_maker.name = 'sh: '.a:sh_command
     let enabled_makers =  [custom_maker]
     call neomake#Make({'enabled_makers': enabled_makers})


### PR DESCRIPTION
My `errorformat` isn't being respected by Neomake when used with `makeprg`.

Here's what I think is happening: I set a new `errorformat`, call `Neomake!`,  then restore the old `errorformat`. The job finishes and Neomake parses the output with the *current* `errorformat` (which is the old `errorformat`) rather than the one I set before calling Neomake! (the new `errorformat`).

Solution is to add an extra `errorformat` argument to MakerFromCommand so that Neomake "remembers" the initial `errorformat`.