### PR TITLE
Add maker for Haskell's hdevtools.

### DIFF
--- a/autoload/neomake/makers/ft/haskell.vim
+++ b/autoload/neomake/makers/ft/haskell.vim
@@ -1,6 +1,22 @@
 
 function! neomake#makers#ft#haskell#EnabledMakers()
-    return ['ghcmod', 'hlint']
+    return ['ghcmod', 'hdevtools', 'hlint']
+endfunction
+
+function! neomake#makers#ft#haskell#hdevtools()
+    return {
+        \ 'exe': 'hdevtools',
+        \ 'args': ['check'],
+        \ 'errorformat':
+            \ '%-G%\s%#,' .
+            \ '%f:%l:%c:%trror: %m,' .
+            \ '%f:%l:%c:%tarning: %m,'.
+            \ '%f:%l:%c: %trror: %m,' .
+            \ '%f:%l:%c: %tarning: %m,' .
+            \ '%f:%l:%c:%m,' .
+            \ '%E%f:%l:%c:,' .
+            \ '%Z%m'
+        \ }
 endfunction
 
 function! neomake#makers#ft#haskell#ghcmod()

--- a/autoload/neomake/makers/ft/haskell.vim
+++ b/autoload/neomake/makers/ft/haskell.vim
@@ -8,14 +8,14 @@ function! neomake#makers#ft#haskell#hdevtools()
         \ 'exe': 'hdevtools',
         \ 'args': ['check'],
         \ 'errorformat':
-            \ '%-G%\s%#,' .
-            \ '%f:%l:%c:%trror: %m,' .
-            \ '%f:%l:%c:%tarning: %m,'.
-            \ '%f:%l:%c: %trror: %m,' .
-            \ '%f:%l:%c: %tarning: %m,' .
-            \ '%f:%l:%c:%m,' .
-            \ '%E%f:%l:%c:,' .
-            \ '%Z%m'
+            \ '%-Z %#,'.
+            \ '%W%f:%l:%v: Warning: %m,'.
+            \ '%W%f:%l:%v: Warning:,'.
+            \ '%E%f:%l:%v: %m,'.
+            \ '%E%>%f:%l:%v:,'.
+            \ '%+C  %#%m,'.
+            \ '%W%>%f:%l:%v:,'.
+            \ '%+C  %#%tarning: %m,'
         \ }
 endfunction
 


### PR DESCRIPTION
This is almost a copy of ghc-mod's maker, but without the null byte check. ghc-mod doesn't quite build with the new version of GHC (7.10.1), at least on my machine, but hdevtools does almost the same thing in a daemonised form and builds nicely.