### PR TITLE
Deepcopy returned maker in GetMaker.

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -113,7 +113,7 @@ function! neomake#GetMaker(name_or_maker, ...) abort
             endtry
         endif
     endif
-    let maker = copy(maker)
+    let maker = deepcopy(maker)
     if !has_key(maker, 'name')
         let maker.name = a:name_or_maker
     endif


### PR DESCRIPTION
The issue is explained in the commit message but the long and short of it is that when `copy()` was used instead of `deepcopy()` the filename would be appended to the args list again each time `MakeJob()` was called.

This becomes an issue if the executable takes a set number of arguments or if passing the filename more than once has undesirable consequences.