### PR TITLE
Make hdevtools emit warnings as well as errors.

### DIFF
--- a/autoload/neomake/makers/ft/haskell.vim
+++ b/autoload/neomake/makers/ft/haskell.vim
@@ -6,7 +6,7 @@ endfunction
 function! neomake#makers#ft#haskell#hdevtools()
     return {
         \ 'exe': 'hdevtools',
-        \ 'args': ['check'],
+        \ 'args': ['check', '-g-Wall'],
         \ 'errorformat':
             \ '%-Z %#,'.
             \ '%W%f:%l:%v: Warning: %m,'.


### PR DESCRIPTION
This simply requests hdevtools to pass the -Wall parameter to GHC when it is running.