### PR TITLE
Add maker for erlang

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,9 @@ Tex/Latex:
 Scala:
 - scalac
 
+Erlang:
+- erlc
+
 Since this list may be out of date, look in [autoload/neomake/makers](https://github.com/benekastah/neomake/tree/master/autoload/neomake/makers) for all supported makers.
 
 If you find this plugin useful, please contribute your maker recipes to the

--- a/autoload/neomake/makers/ft/erlang.vim
+++ b/autoload/neomake/makers/ft/erlang.vim
@@ -1,0 +1,11 @@
+
+function! neomake#makers#ft#erlang#EnabledMakers()
+    return ['erlc']
+endfunction
+
+function! neomake#makers#ft#erlang#erlc()
+    return {
+        \ 'errorformat':
+            \ '%f:%l: %m'
+        \ }
+endfunction


### PR DESCRIPTION
Use erlc as a syntax checker for erlang code.