### PR TITLE
Fix enabled makers setting

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -170,10 +170,10 @@ function! neomake#GetEnabledMakers(...) abort
     let union = {}
     let fts = neomake#utils#GetSortedFiletypes(a:1)
     for ft in fts
-        let varname = 'neomake_'.ft.'_enabled_makers'
+        let varname = 'g:neomake_'.ft.'_enabled_makers'
         let fnname = 'neomake#makers#ft#'.ft.'#EnabledMakers'
         if exists(varname)
-            let enabled_makers = get(g:, varname)
+            let enabled_makers = eval(varname)
         else
             try
                 let default_makers = eval(fnname . '()')


### PR DESCRIPTION
I'm a vimscript novice, so apologies in advance if this isn't the ideal solution, but this seems to fix #135. Looks like it was checking the existence of `neomake_foo_enabled_makers` instead of `g:neomake_foo_enabled_makers`.