### PR TITLE
Rust: faster checks by skipping codegen

### DIFF
--- a/autoload/neomake/makers/ft/rust.vim
+++ b/autoload/neomake/makers/ft/rust.vim
@@ -6,7 +6,7 @@ endfunction
 
 function! neomake#makers#ft#rust#rustc()
     return {
-        \ 'args': ['-o', neomake#utils#DevNull()],
+        \ 'args': ['-Z', 'no-trans'],
         \ 'errorformat':
             \ '%-G%f:%s:,' .
             \ '%f:%l:%c: %trror: %m,' .


### PR DESCRIPTION
rustc has a '-Z no-trans' flag that, when on, skips the costly LLVM code
generation phase, while still reporting all errors and warnings.

Enabling this flag makes linting much faster. It also renders "-o /dev/null"
unnecessary.