### PR TITLE
Escape special characters in filetypes

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -170,6 +170,7 @@ function! neomake#GetEnabledMakers(...) abort
     let union = {}
     let fts = neomake#utils#GetSortedFiletypes(a:1)
     for ft in fts
+        let ft = substitute(ft, '\W', '_', 'g')
         let varname = 'g:neomake_'.ft.'_enabled_makers'
         let fnname = 'neomake#makers#ft#'.ft.'#EnabledMakers'
         if exists(varname)


### PR DESCRIPTION
Filetypes are treated as parts of variable names (using eval()). However, some
characters are legal in a filetype but not in an identifier. This caused the
Neomake command to completely fail when the current filename contained such
characters.

This commit fixes that by replacing all such characters with underscores ('_').

fixes #140