### PR TITLE
Show command output in quickfix list with :NeomakeSh.

### DIFF
--- a/plugin/neomake.vim
+++ b/plugin/neomake.vim
@@ -21,6 +21,7 @@ endfunction
 function! s:NeomakeSh(sh_command)
     let custom_maker = neomake#utils#MakerFromCommand(&shell, a:sh_command)
     let custom_maker.name = 'sh: '.a:sh_command
+    let custom_maker.remove_invalid_entries = 0
     let enabled_makers =  [custom_maker]
     call neomake#Make({'enabled_makers': enabled_makers})
 endfunction


### PR DESCRIPTION
Without this change, :NeomakeSh does not give any visible output unless the user manually set its errorformat before running the command.