### PR TITLE
Add TypeScript Checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,9 @@ Tex/Latex:
 Scala:
 - scalac
 
+TypeScript:
+- tsc
+
 Erlang:
 - erlc
 

--- a/autoload/neomake/makers/ft/typescript.vim
+++ b/autoload/neomake/makers/ft/typescript.vim
@@ -1,0 +1,18 @@
+" vim: ts=4 sw=4 et
+
+function! neomake#makers#ft#typescript#EnabledMakers()
+    return ['tsc']
+endfunction
+
+function! neomake#makers#ft#typescript#tsc()
+    return {
+        \ 'args': [
+            \ '-m', 'commonjs', '--noEmit'
+        \ ],
+        \ 'errorformat':
+            \ '%E%f %#(%l\,%c): error %m,' .
+            \ '%E%f %#(%l\,%c): %m,' .
+            \ '%Eerror %m,' .
+            \ '%C%\s%\+%m'
+        \ }
+endfunction


### PR DESCRIPTION
TypeScript Checker for TS 1.5.

There is no simple way to skip code generation for TS1.4-. But at least I hope this can make the best of evergreen TS compilers. Please refer to https://github.com/scrooloose/syntastic/pull/1382 for more info