### PR TITLE
fix long messages

### DIFF
--- a/autoload/neomake/utils.vim
+++ b/autoload/neomake/utils.vim
@@ -68,7 +68,7 @@ function! neomake#utils#WideMessage(msg) " {{{2
     "convert tabs to spaces so that the tabs count towards the window
     "width as the proper amount of characters
     let chunks = split(msg, "\t", 1)
-    let msg = join(map(chunks[:-2], 'v:val . repeat(" ", &tabstop - s:_width(v:val) % &tabstop)'), '') . chunks[-1]
+    let msg = join(map(chunks[:-2], 'v:val . repeat(" ", &tabstop - strwidth(v:val) % &tabstop)'), '') . chunks[-1]
     let msg = strpart(msg, 0, &columns - 1)
 
     set noruler noshowcmd


### PR DESCRIPTION
looks like this code was copied from syntastic and missed the `s:_width` definition: https://github.com/scrooloose/syntastic/blob/31cba018b381feb99c75a67abde7acc69daf2c50/autoload/syntastic/util.vim#L173