### PR TITLE
Implement jsxhint maker

### DIFF
--- a/autoload/neomake/makers/ft/javascript.vim
+++ b/autoload/neomake/makers/ft/javascript.vim
@@ -11,6 +11,13 @@ function! neomake#makers#ft#javascript#jshint()
         \ }
 endfunction
 
+function! neomake#makers#ft#javascript#jsxhint()
+    return {
+        \ 'args': ['--verbose'],
+        \ 'errorformat': '%A%f: line %l\, col %v\, %m \(%t%*\d\)',
+        \ }
+endfunction
+
 function! neomake#makers#ft#javascript#jscs()
     return {
         \ 'args': ['--no-color', '--reporter', 'inline'],


### PR DESCRIPTION
Adds support for https://github.com/STRML/JSXHint. It can be used via:

```vim
let g:neomake_javascript_enabled_makers = ['jsxhint']
```