### PR TITLE
Add ! To MRI Function To Fix 'Exists' Error

### DIFF
--- a/autoload/neomake/makers/ft/ruby.vim
+++ b/autoload/neomake/makers/ft/ruby.vim
@@ -20,7 +20,7 @@ function! neomake#makers#ft#ruby#RubocopEntryProcess(entry)
     endif
 endfunction
 
-function neomake#makers#ft#ruby#mri()
+function! neomake#makers#ft#ruby#mri()
     let errorformat = '%-G%\m%.%#warning: %\%%(possibly %\)%\?useless use of == in void context,'
     let errorformat .= '%-G%\%.%\%.%\%.%.%#,'
     let errorformat .=


### PR DESCRIPTION
While I had trouble reproducing it, sourcing my .nvimrc would
occasionally cause the following error:

```
Error detected while processing /Users/patrick.regan/.vim/bundle/neomake/autoload/neomake/makers/ft/ruby.vim:
line   40:
E122: Function neomake#makers#ft#ruby#mri already exists, add ! to replace it
Error detected while processing function <SNR>136_NeomakeCommand..neomake#GetEnabledMakers..neomake#utils#GetSortedFiletypes..CompareFiletypes:
line    1:
E171: Missing :endif
Error detected while processing function <SNR>136_NeomakeCommand:
line    2:
E171: Missing :endif
```

Adding the `!` character forces the function to be overwritten.