### PR TITLE
Fixed tslint maker args

### DIFF
--- a/autoload/neomake/makers/ft/typescript.vim
+++ b/autoload/neomake/makers/ft/typescript.vim
@@ -20,7 +20,7 @@ endfunction
 function! neomake#makers#ft#typescript#tslint()
     return {
         \ 'args': [
-            \ '-f', '%:p', '--format verbose'
+            \ '%:p', '--format verbose'
         \ ],
         \ 'errorformat': '%f[%l\, %c]: %m'
         \ }


### PR DESCRIPTION
Fixes this issue:
```
-f option is no longer available. Supply files directly to the tslint command instead.
```
