### PR TITLE
Allow file to be excluded in filetype makers

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,10 @@ will get an error message like `{ makername } not found`.
 
 If the string `'%:p'` shows up anywhere in the `'args'` list, it will be
 `expand()`ed to the full path of the current file in place. Otherwise, the full
-path to the file will be `add()`ed to the end of the list. You can customize
-the program that is called by adding an `'exe'` property which should be a
-string (defaults to the name of the maker).
+path to the file will be `add()`ed to the end of the list, unless the maker's
+`'append_file'` option is set to 0. You can customize the program that is
+called by adding an `'exe'` property which should be a string (defaults to the
+name of the maker).
 
 Once you have created your makers, run `:Neomake` as normal. Run
 `:Neomake <checker-name>` to run only a single checker. Configuring a

--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -67,7 +67,7 @@ function! neomake#MakeJob(maker) abort
     let jobinfo.maker = a:maker
 
     let args = a:maker.args
-    let append_file = a:maker.file_mode && index(args, '%:p') <= 0
+    let append_file = a:maker.file_mode && index(args, '%:p') <= 0 && get(a:maker, 'append_file', 1)
     if append_file
         call add(args, '%:p')
     endif

--- a/autoload/neomake/makers/ft/go.vim
+++ b/autoload/neomake/makers/ft/go.vim
@@ -10,6 +10,7 @@ function! neomake#makers#ft#go#go()
             \ 'build',
             \ '-o', neomake#utils#DevNull()
         \ ],
+        \ 'append_file': 0,
         \ 'errorformat':
             \ '%W%f:%l: warning: %m,' .
             \ '%E%f:%l:%c:%m,' .

--- a/doc/neomake.txt
+++ b/doc/neomake.txt
@@ -104,6 +104,18 @@ but will be retained in the docs for discoverability: >
 This will cause "lint /path/to/file.c --option x" to be run instead of
 "lint --option x /path/to/file.c".
 
+The file path can be excluded from the argument list entirely by setting the
+'append_file' argument to 0. >
+    let g:neomake_c_lint_maker = {
+        \ 'exe': 'lint',
+        \ 'args': ['--option', 'x'],
+        \ 'append_file': 0,
+        \ 'errorformat': '%f:%l:%c: %m',
+        \ }
+<
+This can be useful for makers that are filetype dependent but are typically
+run on an whole project rather than a specific file.
+
                                                      *neomake-makers-processing*
 You can define two optional properties on a maker object to process the maker
 output: 'mapexpr' is applied to the maker output before any processing, and


### PR DESCRIPTION
This PR adds an `append_file` option to the filetype maker specification. If `append_file` is 0, the file path will not be implicitly added to the arguments list. This option is useful for makers such as `go build` and `tsc` that should be run for certain filetypes but are typically run without a file argument. `append_file` is 1 by default to preserve backward compatibility.

The `go` filetype builder has been modified to set `append_file` to 0.

References #196 