### PR TITLE
Add eslint_d maker

### DIFF
--- a/autoload/neomake/makers/ft/javascript.vim
+++ b/autoload/neomake/makers/ft/javascript.vim
@@ -26,6 +26,14 @@ function! neomake#makers#ft#javascript#eslint()
         \ }
 endfunction
 
+function! neomake#makers#ft#javascript#eslint_d()
+    return {
+        \ 'args': ['-f', 'compact'],
+        \ 'errorformat': '%E%f: line %l\, col %c\, Error - %m,' .
+        \ '%W%f: line %l\, col %c\, Warning - %m'
+        \ }
+endfunction
+
 function! neomake#makers#ft#javascript#standard()
     return {
         \ 'errorformat': '  %f:%l:%c: %m'


### PR DESCRIPTION
This PR adds the `eslint_d` JavaScript maker. It wraps `eslint` and avoids delays by preloading the required modules (see [here](https://github.com/mantoni/eslint_d.js)). Its usage is identical to `eslint`.