### PR TITLE
Support for informational and message signs

### DIFF
--- a/autoload/neomake/makers/ft/nim.vim
+++ b/autoload/neomake/makers/ft/nim.vim
@@ -1,0 +1,14 @@
+function! neomake#makers#ft#nim#EnabledMakers()
+    return ['nim']
+endfunction
+
+function! neomake#makers#ft#nim#nim()
+    return {                          
+                \ 'exe': 'nim',                                      
+                \ 'args': ['--verbosity:0', '--colors:off', 'check'],
+                \ 'errorformat':                                     
+                \   '%I%f(%l\, %c) Hint: %m,' .                      
+                \   '%W%f(%l\, %c) Warning: %m,' .                   
+                \   '%E%f(%l\, %c) Error: %m'                        
+                \ }                                                  
+endfunction

--- a/autoload/neomake/signs.vim
+++ b/autoload/neomake/signs.vim
@@ -63,7 +63,15 @@ endfunction
 
 " type may be either 'file' or 'project'
 function! neomake#signs#PlaceSign(entry, type) abort
-    let sign_type = a:entry.type ==# 'E' ? 'neomake_err' : 'neomake_warn'
+    if a:entry.type ==# 'W'
+        let sign_type = 'neomake_warn'
+    elseif a:entry.type ==# 'I'
+        let sign_type = 'neomake_info'
+    elseif a:entry.type ==# 'M'
+        let sign_type = 'neomake_msg'
+    else
+        let sign_type = 'neomake_err'
+    endif
 
     let s:placed_signs[a:type][a:entry.bufnr] = get(s:placed_signs[a:type], a:entry.bufnr, {})
     if !has_key(s:placed_signs[a:type][a:entry.bufnr], a:entry.lnum)
@@ -159,6 +167,30 @@ function! neomake#signs#RedefineErrorSign(...)
     call neomake#signs#RedefineSign('neomake_err', opts)
 endfunction
 
+function! neomake#signs#RedefineMessageSign(...)
+    let default_opts = {'text': '➤'}
+    let opts = {}
+    if a:0
+        call extend(opts, a:1)
+    elseif exists('g:neomake_message_sign')
+        call extend(opts, g:neomake_message_sign)
+    endif
+    call extend(opts, default_opts, 'keep')
+    call neomake#signs#RedefineSign('neomake_msg', opts)
+endfunction
+
+function! neomake#signs#RedefineInformationalSign(...)
+    let default_opts = {'text': 'ℹ'}
+    let opts = {}
+    if a:0
+        call extend(opts, a:1)
+    elseif exists('g:neomake_informational_sign')
+        call extend(opts, g:neomake_informational_sign)
+    endif
+    call extend(opts, default_opts, 'keep')
+    call neomake#signs#RedefineSign('neomake_info', opts)
+endfunction
+
 function! neomake#signs#RedefineWarningSign(...)
     let default_opts = {'text': '⚠'}
     let opts = {}
@@ -177,5 +209,7 @@ function! neomake#signs#DefineSigns()
         let s:signs_defined = 1
         call neomake#signs#RedefineErrorSign()
         call neomake#signs#RedefineWarningSign()
+        call neomake#signs#RedefineInformationalSign()
+        call neomake#signs#RedefineMessageSign()
     endif
 endfunction


### PR DESCRIPTION
Vim errorformat has support for error (%E), warning (%W), informational (%I) and general message(%A). Neomake only uses errors and warnings currently. I see no reason why it shouldn't support %I and %A also.