### PR TITLE
Allow b: variables for overriding maker settings

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -158,14 +158,16 @@ function! neomake#GetMaker(name_or_maker, ...) abort
         if len(fts)
             for ft in fts
                 let config_var = 'neomake_'.ft.'_'.maker.name.'_'.key
-                if has_key(g:, config_var)
+                if has_key(g:, config_var) || has_key(b:, config_var)
                     break
                 endif
             endfor
         else
             let config_var = 'neomake_'.maker.name.'_'.key
         endif
-        if has_key(g:, config_var)
+        if has_key(b:, config_var)
+            let maker[key] = copy(get(b:, config_var))
+        elseif has_key(g:, config_var)
             let maker[key] = copy(get(g:, config_var))
         elseif !has_key(maker, key)
             let maker[key] = defaults[key]

--- a/doc/neomake.txt
+++ b/doc/neomake.txt
@@ -177,8 +177,9 @@ Define a new filetype or project-level maker. See |neomake-makers|.
 
 *g:neomake_<name>_<property>* *g:neomake_<ft>_<name>_<property>*
 Configure a property for a prexisting maker where property is one of 'exe',
-'args', 'errorformat' or 'buffer_output'. Example: >
+'args', 'errorformat' or 'buffer_output'. Can also be set by buffer. Example: >
     let g:neomake_javascript_jshint_exe = './myjshint'
+    let b:neomake_javascript_jshint_exe = './myotherjshint'
 <
 *g:neomake_<ft>_enabled_makers*
 This setting will tell neomake which makers to use by default for the given


### PR DESCRIPTION
Closes #217 

Previously setting overrides for just the current buffer wasn't possible:
  `let b:neomake_javascript_eslint_args = ['-c', '.eslintes6rc', '-f', 'compact']`

This now allows us to set different rules easily for a certain buffer
type.

```vim
autocmd BufRead,BufNewFile *.es6 call s:setupES6File()

let g:neomake_javascript_enabled_makers = ['eslint']

let g:neomake_javascript_eslint_args = ['-c', '.eslintrc']

function! s:setupES6File()
  setfiletype javascript " Set filetype
  " For the current buffer, use the special es6 eslint ruleset
  let b:neomake_javascript_eslint_args = ['-c', '.eslintes6rc']
endfunction
```