### PR TITLE
Add clang-tidy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,10 +115,12 @@ Ruby:
 C:
 - clang
 - gcc
+- clang-tidy
 
 C++:
 - clang++
 - g++
+- clang-tidy
 
 D:
 - dmd

--- a/autoload/neomake/makers/ft/c.vim
+++ b/autoload/neomake/makers/ft/c.vim
@@ -46,20 +46,12 @@ function! neomake#makers#ft#c#gcc()
         \ }
 endfunction
 
+" The -p option followed by the path to the build directory should be set in
+" the maker's arguments. That directory should contain the compile command
+" database (compile_commands.json).
 function! neomake#makers#ft#c#clangtidy()
-    " Default arguments.
-    let l:args = []
-
-    " Add user-defined arguments if some are set.
-    " The -p option followed by the path to the build directory is expected.
-    " That directory should contain the compile command database
-    " (compile_commands.json).
-    if exists("g:neomake_c_clangtidy_args_conf")
-        let l:args += g:neomake_c_clangtidy_args_conf
-    endif
     return {
         \ 'exe': 'clang-tidy',
-        \ 'args': l:args,
         \ 'errorformat':
             \ '%E%f:%l:%c: fatal error: %m,' .
             \ '%E%f:%l:%c: error: %m,' .

--- a/autoload/neomake/makers/ft/c.vim
+++ b/autoload/neomake/makers/ft/c.vim
@@ -1,11 +1,17 @@
 " vim: ts=4 sw=4 et
 
 function! neomake#makers#ft#c#EnabledMakers()
+    let makers = []
     if neomake#utils#Exists('clang')
-        return ['clang']
+        call add(makers, 'clang')
+
+        if neomake#utils#Exists('clang-tidy')
+            call add(makers, 'clangtidy')
+        endif
     else
-        return ['gcc']
+        call add(makers, 'gcc')
     end
+    return makers
 endfunction
 
 function! neomake#makers#ft#c#clang()
@@ -37,5 +43,28 @@ function! neomake#makers#ft#c#gcc()
             \ '%f:%l: %trror: %m,' .
             \ '%f:%l: %tarning: %m,'.
             \ '%f:%l: %m',
+        \ }
+endfunction
+
+function! neomake#makers#ft#c#clangtidy()
+    " Default arguments.
+    let l:args = []
+
+    " Add user-defined arguments if some are set.
+    " The -p option followed by the path to the build directory is expected.
+    " That directory should contain the compile command database
+    " (compile_commands.json).
+    if exists("g:neomake_c_clangtidy_args_conf")
+        let l:args += g:neomake_c_clangtidy_args_conf
+    endif
+    return {
+        \ 'exe': 'clang-tidy',
+        \ 'args': l:args,
+        \ 'errorformat':
+            \ '%E%f:%l:%c: fatal error: %m,' .
+            \ '%E%f:%l:%c: error: %m,' .
+            \ '%W%f:%l:%c: warning: %m,' .
+            \ '%-G%\m%\%%(LLVM ERROR:%\|No compilation database found%\)%\@!%.%#,' .
+            \ '%E%m',
         \ }
 endfunction

--- a/autoload/neomake/makers/ft/cpp.vim
+++ b/autoload/neomake/makers/ft/cpp.vim
@@ -19,3 +19,8 @@ function! neomake#makers#ft#cpp#gcc()
     let maker.exe = 'g++'
     return maker
 endfunction
+
+function! neomake#makers#ft#cpp#clangtidy()
+    let maker = neomake#makers#ft#c#clangtidy()
+    return maker
+endfunction


### PR DESCRIPTION
`g:neomake_c_clangtidy_args_conf` needs to be properly set, especially with the `-p` option indicating the build directory containing the compile command database.