### PR TITLE
Make ghc-mod's messages errors by default

### DIFF
--- a/autoload/neomake/makers/ft/haskell.vim
+++ b/autoload/neomake/makers/ft/haskell.vim
@@ -33,7 +33,7 @@ function! neomake#makers#ft#haskell#ghcmod()
             \ '%f:%l:%c:%tarning: %m,'.
             \ '%f:%l:%c: %trror: %m,' .
             \ '%f:%l:%c: %tarning: %m,' .
-            \ '%f:%l:%c:%m,' .
+            \ '%E%f:%l:%c:%m,' .
             \ '%E%f:%l:%c:,' .
             \ '%Z%m'
         \ }


### PR DESCRIPTION
When ghc-mod doesn't include `Warning` in the error message it's an error