### PR TITLE
Improve Flow error processing

### DIFF
--- a/autoload/neomake/makers/ft/javascript.vim
+++ b/autoload/neomake/makers/ft/javascript.vim
@@ -45,7 +45,7 @@ function! neomake#makers#ft#javascript#flow()
     let mapexpr = 'substitute(v:val, "\\\\n", " ", "g")'
     return {
         \ 'args': ['check', '--one-line'],
-        \ 'errorformat': '%f:%l:%c\,%n: %m',
+        \ 'errorformat': '%f:%l %m',
         \ 'mapexpr': mapexpr,
         \ }
 endfunction


### PR DESCRIPTION
## Problem:

Flow has recently updated its error message format,
and as a result Neomake no longer recognizes Flow error messages.
There is no longer an alert icon in the file's gutter next to offending lines.

Neomake expects the error message to report the character position of the error,
but Flow doesn't actually report this information.

Here is the a sample of the old output from Flow:

```
2.2.3 sandbox/flow  flow check --old-output-format

/Users/grayson/dev/sandbox/flow/foobar.js:6:1,14: function call
Error:
/Users/grayson/dev/sandbox/flow/foobar.js:3:10,12: string
This type is incompatible with
/Users/grayson/dev/sandbox/flow/foobar.js:3:10,16: number

Found 1 error
```

Here is a sample of the new output from Flow:

```
foobar.js:6
  6: hello("hello");
     ^^^^^^^^^^^^^^ function call
  3:   return foo * 3;
              ^^^ string. This type is incompatible with
  3:   return foo * 3;
              ^^^^^^^ number


Found 1 error
```

With the `--one-line` argument, it looks like:

```
foobar.js:6\n  6: hello("hello");\n     ^^^^^^^^^^^^^^ function call\n  3:   return foo * 3;\n              ^^^ string. This type is incompatible with\n  3:   return foo * 3;\n              ^^^^^^^ number\n

Found 1 error
```

## Solution:

Modify Flow's `errorformat` so Neomake doesn't expect a character number,
which wasn't actually being displayed.

This fixes the alert icon in vim's gutter, but still results in a messy error message in the statusline.

## Alternative solutions:

1. Change the `args` option to: `['check', '--old-output-format']
2. Change the `args` option to: `['check', '--json']`, and parse the resulting JSON in order to get the appropriate messages.