### PR TITLE
Prevent certain maker args from silently vanishing

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -71,7 +71,14 @@ function! neomake#MakeJob(maker) abort
     if append_file
         call add(args, '%:p')
     endif
-    call map(args, 'expand(v:val)')
+    function! s:expandIfValid(arg) abort
+        if expand(a:arg) != ""
+            return expand(a:arg)
+        else
+            return a:arg
+        endif
+    endfunction
+    call map(args, 's:expandIfValid(v:val)')
 
     if has_key(a:maker, 'cwd')
         let old_wd = getcwd()


### PR DESCRIPTION
In some rare cases, args passed to the maker (such as colon separated
classpaths) can be overidden to become an empty string by expand()

This commit fixes this by employing a utility function that is then
passed to map