### PR TITLE
rubberinfo: recognize multi-line errors

### DIFF
--- a/autoload/neomake/makers/ft/tex.vim
+++ b/autoload/neomake/makers/ft/tex.vim
@@ -37,6 +37,7 @@ function! neomake#makers#ft#tex#rubberinfo()
         \ 'exe': 'rubber-info',
         \ 'errorformat':
             \ '%f:%l: %m,' .
+            \ '%f:%l-%\d%\+: %m,' .
             \ '%f: %m'
         \ }
 endfunction


### PR DESCRIPTION
This parses for example the following warning from rubber-info:
```
/home/gebner/maxsatalg/maxsatalg.tex:576-587: Underfull \hbox (badness 1132) (page 7)
```