### PR TITLE
Fix Flow Maker

### DIFF
--- a/autoload/neomake/makers/ft/javascript.vim
+++ b/autoload/neomake/makers/ft/javascript.vim
@@ -41,15 +41,6 @@ function! neomake#makers#ft#javascript#standard()
 endfunction
 
 function! neomake#makers#ft#javascript#flow()
-    " Multi-line Vim
-    " \ 'errorformat': '%CFile %m%.%#,%AFile "%f"\, line %l\, characters %c-%.%#,%+G%m,%Z%m,%-G%.%#'
-
-    " Single-line Vim - Long
-    " 'errorformat': '%CFile %m%.%#,%AFile "%f"\, line %l\, characters %c-%.%#,%C%m,%Z%m,%-G%.%#'
-
-    " Single-line Vim - Short
-    " \ 'errorformat': '%CFile %.%#,%AFile "%f"\, line %l\, characters %c-%.%#,%C%m,%Z%m,%-G%.%#'
-
     return {
         \ 'args': ['--from=vim'],
         \ 'errorformat': '%CFile %.%#,%AFile "%f"\, line %l\, characters %c-%.%#,%C%m,%Z%m'

--- a/autoload/neomake/makers/ft/javascript.vim
+++ b/autoload/neomake/makers/ft/javascript.vim
@@ -41,11 +41,17 @@ function! neomake#makers#ft#javascript#standard()
 endfunction
 
 function! neomake#makers#ft#javascript#flow()
-    " Replace "\n" by space.
-    let mapexpr = 'substitute(v:val, "\\\\n", " ", "g")'
+    " Multi-line Vim
+    " \ 'errorformat': '%CFile %m%.%#,%AFile "%f"\, line %l\, characters %c-%.%#,%+G%m,%Z%m,%-G%.%#'
+
+    " Single-line Vim - Long
+    " 'errorformat': '%CFile %m%.%#,%AFile "%f"\, line %l\, characters %c-%.%#,%C%m,%Z%m,%-G%.%#'
+
+    " Single-line Vim - Short
+    " \ 'errorformat': '%CFile %.%#,%AFile "%f"\, line %l\, characters %c-%.%#,%C%m,%Z%m,%-G%.%#'
+
     return {
-        \ 'args': ['check', '--one-line'],
-        \ 'errorformat': '%f:%l:%c\,%n: %m',
-        \ 'mapexpr': mapexpr,
+        \ 'args': ['--from=vim'],
+        \ 'errorformat': '%CFile %.%#,%AFile "%f"\, line %l\, characters %c-%.%#,%C%m,%Z%m'
         \ }
 endfunction


### PR DESCRIPTION
The current flow maker errorformat is being flagged as invalid and thus being
removed from the location list (#27).  This results in Vim just saying that the
maker exited with an error code, but not actually listing any errors.  In an
attempt to display errors in the location list, I'm experimenting with different
errorformats.

Flow can output different error strings depending on the arguments passed, one
of which is '--from=vim' which is a little easier to parse for Vim than the
standard output.  However, the resulting message is arguably too cryptic to
understand without more context, hence attempts to try different formats.