### PR TITLE
Fix typo in color CLI option for JSCS maker

### DIFF
--- a/autoload/neomake/makers/ft/javascript.vim
+++ b/autoload/neomake/makers/ft/javascript.vim
@@ -13,7 +13,7 @@ endfunction
 
 function! neomake#makers#ft#javascript#jscs()
     return {
-        \ 'args': ['--no-color', '--reporter', 'inline'],
+        \ 'args': ['--no-colors', '--reporter', 'inline'],
         \ 'errorformat': '%f: line %l\, col %c\, %m',
         \ }
 endfunction


### PR DESCRIPTION
The latest JSCS uses `--no-colors` and not `--no-color`