### PR TITLE
Improve cargo errorformat

### DIFF
--- a/autoload/neomake/makers/cargo.vim
+++ b/autoload/neomake/makers/cargo.vim
@@ -4,12 +4,8 @@ function! neomake#makers#cargo#cargo()
     return {
         \ 'args': ['build'],
         \ 'errorformat':
-            \ '%-G%f:%s:,' .
-            \ '%f:%l:%c: %trror: %m,' .
-            \ '%f:%l:%c: %tarning: %m,' .
-            \ '%f:%l:%c: %m,'.
-            \ '%f:%l: %trror: %m,'.
-            \ '%f:%l: %tarning: %m,'.
-            \ '%f:%l: %m',
+            \   '%-Z%f:%l,' .
+            \   '%+C %s,' .
+            \   '%A%f:%l:%c: %*\d:%*\d\ %t%*[^:]: %m,',
         \ }
 endfunction


### PR DESCRIPTION
The current cargo `errorformat` does not display what actually triggered the error. This PR adds the reason message, as well as some additional text from the message.

Parts of the message that are not indented are not displayed because

1. It is difficult to distinguish message text from other text (like help messages).
2. It greatly increases the size of the message with likely unnecessary information.

I am also going to attempt to get this `errorformat` merged into `rust.vim` upstream. That `errorformat` at least handles *what* triggered the error (e.g., "mismatched types"), but it does not display the additional text ("expected `collections::vec::Vec<u8>`,    found `&char`").