### PR TITLE
Add YAML maker: yamllint

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,9 @@ Markdown:
 Pug:
 - [pug-lint](https://github.com/pugjs/pug-lint)
 
+YAML:
+- [yamllint](http://yamllint.readthedocs.org/)
+
 Since this list may be out of date, look in [autoload/neomake/makers](https://github.com/benekastah/neomake/tree/master/autoload/neomake/makers) for all supported makers.
 
 If you find this plugin useful, please contribute your maker recipes to the

--- a/autoload/neomake/makers/ft/yaml.vim
+++ b/autoload/neomake/makers/ft/yaml.vim
@@ -1,0 +1,12 @@
+" vim: ts=4 sw=4 et
+
+function! neomake#makers#ft#yaml#EnabledMakers()
+    return ['yamllint']
+endfunction
+
+function! neomake#makers#ft#yaml#yamllint()
+    return {
+        \ 'args': ['-f', 'parsable'],
+        \ 'errorformat': '%E%f:%l:%c: [error] %m,%W%f:%l:%c: [warning] %m',
+        \ }
+endfunction


### PR DESCRIPTION
yamllint [1] is a linter for YAML files. It does not only check for
syntax validity, but for common cosmetic conventions such as lines
length, trailing spaces, indentation, etc.

[1: http://yamllint.readthedocs.org/](http://yamllint.readthedocs.org/)