### PR TITLE
added pug-lint for pug filetype

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,9 @@ Standard ML:
 Markdown:
 - mdl
 
+Pug:
+- [pug-lint](https://github.com/pugjs/pug-lint)
+
 Since this list may be out of date, look in [autoload/neomake/makers](https://github.com/benekastah/neomake/tree/master/autoload/neomake/makers) for all supported makers.
 
 If you find this plugin useful, please contribute your maker recipes to the

--- a/autoload/neomake/makers/ft/pug.vim
+++ b/autoload/neomake/makers/ft/pug.vim
@@ -1,0 +1,13 @@
+" vim: ts=4 sw=4 et
+
+function! neomake#makers#ft#pug#EnabledMakers()
+    return ['puglint']
+endfunction
+
+function! neomake#makers#ft#pug#puglint()
+    return {
+        \ 'exe': 'pug-lint',
+        \ 'args': ['--reporter', 'inline'],
+        \ 'errorformat': '%f:%l:%c %m'
+        \ }
+endfunction


### PR DESCRIPTION
Since [Jade has been renamed to Pug](https://github.com/pugjs/jade/issues/2184), so too has the [linter](https://github.com/pugjs/pug-lint).

This is essentially a copy of the previous [maker for Jade](https://github.com/benekastah/neomake/blob/82fb2d2183cf9143cf17b0641b84921f0495c81d/autoload/neomake/makers/ft/jade.vim).