### PR TITLE
[RDY] Add Windows support and Apache Maven builder

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -37,7 +37,11 @@ function! s:JobStart(make_id, exe, ...) abort
         return jobstart(argv, opts)
     else
         if has_args
-            let program = a:exe.' '.join(map(a:1, 'shellescape(v:val)'))
+            if neomake#utils#IsRunningWindows()
+                let program = a:exe.' '.join(map(a:1, 'v:val'))
+            else
+                let program = a:exe.' '.join(map(a:1, 'shellescape(v:val)'))
+            endif
         else
             let program = a:exe
         endif
@@ -71,7 +75,13 @@ function! neomake#MakeJob(maker) abort
     if append_file
         call add(args, '%:p')
     endif
-    call map(args, 'expand(v:val)')
+
+    if neomake#utils#IsRunningWindows()
+        " Don't expand &shellcmdflag argument of cmd.exe
+        call map(args, 'v:val !=? &shellcmdflag ? expand(v:val) : v:val')
+    else
+        call map(args, 'expand(v:val)')
+    endif
 
     if has_key(a:maker, 'cwd')
         let old_wd = getcwd()

--- a/autoload/neomake/makers/mvn.vim
+++ b/autoload/neomake/makers/mvn.vim
@@ -1,0 +1,9 @@
+" vim: ts=4 sw=4 et
+
+function! neomake#makers#mvn#mvn()
+    return {
+         \ 'exe': 'mvn',
+         \ 'args': ['install'],
+            \ 'errorformat': '[%tRROR]\ %f:[%l]\ %m,%-G%.%#'
+         \ }
+endfunction

--- a/autoload/neomake/utils.vim
+++ b/autoload/neomake/utils.vim
@@ -129,8 +129,10 @@ function! neomake#utils#MakerFromCommand(shell, command) abort
             \shell_name) >= 0
         let args = ['-c', command]
     else
-        " TODO Windows support (at least)
-        throw "Shell not recognized; can't build command"
+        let shell_name = split(a:shell, '\\')[-1]
+        if (shell_name == 'cmd.exe')
+            let args = [&shellcmdflag, command]
+        endif
     endif
     return {
         \ 'exe': a:shell,


### PR DESCRIPTION
This PR adds Windows support to Neomake and adds a maker for Apache Maven (https://maven.apache.org/). Thanks to @equalsraf, this actually appears to be working. Because Maven is a project based builder, it was necessary to introduce the mvn maker outside of the `ft` directory. It can be invoked thusly: `Neomake! mvn`. Because the exact arguments that one uses to invoke Maven vary so widely between projects, it is recommended to override the default `install` argument by specifying:

````
let g:neomake_mvn_args=['package', '-P', 'unitTests', '-T', '2']
````