### PR TITLE
Fix python maker for Vim: use \r instead of \n

### DIFF
--- a/autoload/neomake/makers/ft/python.vim
+++ b/autoload/neomake/makers/ft/python.vim
@@ -128,13 +128,13 @@ endfunction
 function! neomake#makers#ft#python#python()
     return {
         \ 'args': [ '-c',
-            \ "from __future__ import print_function\n" .
-            \ "from sys import argv, exit\n" .
-            \ "if len(argv) != 2:\n" .
-            \ "    exit(1)\n" .
-            \ "try:\n" .
-            \ "    compile(open(argv[1]).read(), argv[1], 'exec', 0, 1)\n" .
-            \ "except SyntaxError as err:\n" .
+            \ "from __future__ import print_function\r" .
+            \ "from sys import argv, exit\r" .
+            \ "if len(argv) != 2:\r" .
+            \ "    exit(1)\r" .
+            \ "try:\r" .
+            \ "    compile(open(argv[1]).read(), argv[1], 'exec', 0, 1)\r" .
+            \ "except SyntaxError as err:\r" .
             \ "    print('%s:%s:%s: %s' % (err.filename, err.lineno, err.offset, err.msg))"
         \ ],
         \ 'errorformat': '%E%f:%l:%c: %m',


### PR DESCRIPTION
When using Vim instead of Neovim, the python maker failed like this:

> Neomake: python stdout:   File "<string>", line 2
> Neomake: python stdout:     from sys import argv, exit\
> Neomake: python stdout:        ^
> Neomake: python stdout: SyntaxError: invalid syntax
> Neomake: python stdout:
> Neomake: python stdout done.
> Neomake: python processing 5 lines of output
> Neomake: File-level errors cleaned in buffer 1

It seems like we have to use "\r" for newlines, instead of "\n".